### PR TITLE
feat(lib,example): structural directives for node and edge templates

### DIFF
--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -42,7 +42,7 @@
     </form>
   </div>
 
-  <lib-graph [edges]="edges" [nodes]="nodes">
+  <lib-graph>
     <ng-container *defsTemplate>
       <svg:marker
         class="arrow"

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -17,7 +17,7 @@
       <select class="create-edge-form__select" formControlName="sourceId">
         <option value="" selected disabled>Select a node</option>
         <option *ngFor="let node of nodes" [value]="node.id">
-          {{ node.data.title }}
+          {{ node.data?.title }}
         </option>
       </select>
 
@@ -25,7 +25,7 @@
       <select class="create-edge-form__select" formControlName="targetId" placeholder="Select a node">
         <option value="" selected disabled>Select a node</option>
         <option *ngFor="let node of nodes" [value]="node.id">
-          {{ node.data.title }}
+          {{ node.data?.title }}
         </option>
       </select>
 

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -43,7 +43,7 @@
   </div>
 
   <lib-graph [edges]="edges" [nodes]="nodes">
-    <ng-template #defsTemplate>
+    <ng-container *defsTemplate>
       <svg:marker
         class="arrow"
         id="arrow"
@@ -56,9 +56,9 @@
       >
         <svg:path d="M0,-5L10,0L0,5" />
       </svg:marker>
-    </ng-template>
+    </ng-container>
 
-    <ng-template #nodeTemplate let-node>
+    <ng-container *nodeTemplate="let node">
       <svg:g xmlns="http://www.w3.org/2000/xhtml" width="400" height="80" (click)="showNodeUpdateForm(node.id)">
         <svg:foreignObject width="400" height="80">
           <xhtml:div class="node" xmlns="http://www.w3.org/1999/xhtml">
@@ -66,12 +66,12 @@
           </xhtml:div>
         </svg:foreignObject>
       </svg:g>
-    </ng-template>
+    </ng-container>
 
-    <ng-template #edgeTemplate let-edge>
+    <ng-container *edgeTemplate="let edge">
       <svg:g class="edge">
         <svg:path class="edge__line" marker-end="url(#arrow)" [attr.d]="edge.pathDefinition"></svg:path>
       </svg:g>
-    </ng-template>
+    </ng-container>
   </lib-graph>
 </div>

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -58,7 +58,7 @@
       </svg:marker>
     </ng-container>
 
-    <ng-container *nodeTemplate="let node">
+    <ng-container *nodeTemplate="let node; nodes: nodes">
       <svg:g xmlns="http://www.w3.org/2000/xhtml" width="400" height="80" (click)="showNodeUpdateForm(node.id)">
         <svg:foreignObject width="400" height="80">
           <xhtml:div class="node" xmlns="http://www.w3.org/1999/xhtml">
@@ -68,7 +68,7 @@
       </svg:g>
     </ng-container>
 
-    <ng-container *edgeTemplate="let edge">
+    <ng-container *edgeTemplate="let edge; edges: edges">
       <svg:g class="edge">
         <svg:path class="edge__line" marker-end="url(#arrow)" [attr.d]="edge.pathDefinition"></svg:path>
       </svg:g>

--- a/example/src/app/app.component.ts
+++ b/example/src/app/app.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
 import { FormGroup, Validators, FormBuilder } from '@angular/forms';
+import { InputEdge, InputNode } from 'graphy-ng';
+
+interface NodeData {
+  title: string;
+}
 
 @Component({
   selector: 'app-root',
@@ -7,7 +12,7 @@ import { FormGroup, Validators, FormBuilder } from '@angular/forms';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
-  nodes = [
+  nodes: InputNode<NodeData>[] = [
     {
       id: '1',
       data: {
@@ -22,7 +27,7 @@ export class AppComponent {
     },
   ];
 
-  edges = [
+  edges: InputEdge[] = [
     {
       id: '1',
       sourceId: '1',
@@ -93,7 +98,7 @@ export class AppComponent {
 
     // Fill the update form with the existing title.
     const nodeToUpdate = this.nodes.find((node) => node.id === nodeId);
-    this.updateNodeForm.setValue({ title: nodeToUpdate?.data.title });
+    this.updateNodeForm.setValue({ title: nodeToUpdate?.data?.title });
   }
 
   /**

--- a/lib/src/graph/graph.component.html
+++ b/lib/src/graph/graph.component.html
@@ -1,7 +1,7 @@
 <div class="graph" [attr.width]="width" [attr.height]="height">
   <svg:svg class="graph-container" [attr.viewBox]="stringifiedViewBox$ | async" #graphContainer>
     <defs class="defs">
-      <ng-container *ngIf="defsTemplate" [ngTemplateOutlet]="defsTemplate"></ng-container>
+      <ng-container *ngIf="defsTemplate" [ngTemplateOutlet]="defsTemplate.template"></ng-container>
     </defs>
 
     <ng-content></ng-content>
@@ -17,7 +17,7 @@
       >
         <ng-container
           *ngIf="nodeTemplate"
-          [ngTemplateOutlet]="nodeTemplate"
+          [ngTemplateOutlet]="nodeTemplate.template"
           [ngTemplateOutletContext]="{ $implicit: node }"
         ></ng-container>
 
@@ -29,7 +29,7 @@
       <svg:g *ngFor="let edge of transformedEdges; trackBy: trackById" class="edge" [id]="edge.id" #edge>
         <ng-container
           *ngIf="edgeTemplate"
-          [ngTemplateOutlet]="edgeTemplate"
+          [ngTemplateOutlet]="edgeTemplate.template"
           [ngTemplateOutletContext]="{ $implicit: edge }"
         ></ng-container>
 

--- a/lib/src/graph/graph.component.ts
+++ b/lib/src/graph/graph.component.ts
@@ -34,14 +34,6 @@ import { DefsTemplateDirective, EdgeTemplateDirective, NodeTemplateDirective } f
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, OnDestroy {
-  /** The array of nodes to display in the graph. */
-  // TODO: Rename property to `inputNodes`.
-  @Input() nodes: InputNode<NData>[] = [];
-
-  /** The array of edges to display in the graph. */
-  // TODO: Rename property to `inputEdges`.
-  @Input() edges: InputEdge<EData>[] = [];
-
   /** The d3.curve used for defining the shape of edges. */
   @Input() curve: CurveFactory = curveBasis;
 
@@ -103,6 +95,16 @@ export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, O
 
   transformedNodes: TransformedNode[] = [];
   transformedEdges: TransformedEdge[] = [];
+
+  /** The array of nodes to display in the graph. */
+  private get inputNodes(): InputNode<NData>[] {
+    return this.nodeTemplate.inputNodes;
+  }
+
+  /** The array of edges to display in the graph. */
+  private get inputEdges(): InputEdge<EData>[] {
+    return this.edgeTemplate.inputEdges;
+  }
 
   constructor(private el: ElementRef<HTMLElement>, private cd: ChangeDetectorRef) {}
 
@@ -181,7 +183,7 @@ export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, O
       this.renderNodesOffscreen();
     }
 
-    for (let node of this.nodes) {
+    for (let node of this.inputNodes) {
       // The dimensions of every node need to be known before passing it to the layout engine.
       if (this.nodeTemplate) {
         const { width, height } = this.getNodeDimensions(node.id);
@@ -193,7 +195,7 @@ export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, O
       }
     }
 
-    for (let edge of this.edges) {
+    for (let edge of this.inputEdges) {
       graph.setEdge(edge.sourceId, edge.targetId);
     }
 
@@ -211,7 +213,7 @@ export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, O
       transform: `translate(${node.value.x - node.value.width / 2}, ${node.value.y - node.value.height / 2})`,
       isVisible: true,
       data: {
-        ...this.nodes.find((e) => e.id === node.v).data,
+        ...this.inputNodes.find((e) => e.id === node.v).data,
       },
     }));
 
@@ -238,7 +240,7 @@ export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, O
     // The node width, height, x, and y values provided here are completely arbitrary. The point
     // is to render the nodes in the DOM to see what width/height they will actually take up and
     // later provide that to the layout engine.
-    this.transformedNodes = this.nodes.map((node) => ({
+    this.transformedNodes = this.inputNodes.map((node) => ({
       id: node.id,
       width: 1,
       height: 1,

--- a/lib/src/graph/graph.component.ts
+++ b/lib/src/graph/graph.component.ts
@@ -33,7 +33,7 @@ import { DefsTemplateDirective, EdgeTemplateDirective, NodeTemplateDirective } f
   styleUrls: ['./graph.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GraphComponent<NData extends object, EData extends object> implements AfterViewInit, OnChanges, OnDestroy {
+export class GraphComponent<NData, EData> implements AfterViewInit, OnChanges, OnDestroy {
   /** The array of nodes to display in the graph. */
   // TODO: Rename property to `inputNodes`.
   @Input() nodes: InputNode<NData>[] = [];

--- a/lib/src/graph/graph.component.ts
+++ b/lib/src/graph/graph.component.ts
@@ -3,7 +3,6 @@ import {
   ChangeDetectionStrategy,
   Input,
   ContentChild,
-  TemplateRef,
   ElementRef,
   EventEmitter,
   QueryList,
@@ -26,6 +25,7 @@ import { InputNode } from './models/input-node.model';
 import { TransformedEdge } from './models/transformed-edge.model';
 import { TransformedNode } from './models/transformed-node.model';
 import { ViewBox } from './models/view-box.model';
+import { DefsTemplateDirective, EdgeTemplateDirective, NodeTemplateDirective } from './templates';
 
 @Component({
   selector: 'lib-graph',
@@ -33,14 +33,14 @@ import { ViewBox } from './models/view-box.model';
   styleUrls: ['./graph.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
+export class GraphComponent<NData extends object, EData extends object> implements AfterViewInit, OnChanges, OnDestroy {
   /** The array of nodes to display in the graph. */
   // TODO: Rename property to `inputNodes`.
-  @Input() nodes: InputNode[] = [];
+  @Input() nodes: InputNode<NData>[] = [];
 
   /** The array of edges to display in the graph. */
   // TODO: Rename property to `inputEdges`.
-  @Input() edges: InputEdge[] = [];
+  @Input() edges: InputEdge<EData>[] = [];
 
   /** The d3.curve used for defining the shape of edges. */
   @Input() curve: CurveFactory = curveBasis;
@@ -75,9 +75,9 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnDestroy {
   /** Event emitted on component destroy. */
   private readonly onDestroy$: Subject<void> = new Subject();
 
-  @ContentChild('defsTemplate') defsTemplate: TemplateRef<any>;
-  @ContentChild('edgeTemplate') edgeTemplate: TemplateRef<any>;
-  @ContentChild('nodeTemplate') nodeTemplate: TemplateRef<any>;
+  @ContentChild(DefsTemplateDirective) defsTemplate: DefsTemplateDirective;
+  @ContentChild(EdgeTemplateDirective) edgeTemplate: EdgeTemplateDirective<EData>;
+  @ContentChild(NodeTemplateDirective) nodeTemplate: NodeTemplateDirective<NData>;
 
   @ViewChild('graphContainer') graphContainer: ElementRef<SVGSVGElement>;
   @ViewChild('nodesContainer') nodesContainer: ElementRef<SVGSVGElement>;

--- a/lib/src/graph/graph.module.ts
+++ b/lib/src/graph/graph.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { GraphComponent } from './graph.component';
+import { DefsTemplateDirective, EdgeTemplateDirective, NodeTemplateDirective } from './templates';
 
 @NgModule({
-  declarations: [GraphComponent],
+  declarations: [DefsTemplateDirective, EdgeTemplateDirective, GraphComponent, NodeTemplateDirective],
   imports: [CommonModule],
-  exports: [GraphComponent],
+  exports: [DefsTemplateDirective, EdgeTemplateDirective, GraphComponent, NodeTemplateDirective],
 })
 export class GraphModule {}

--- a/lib/src/graph/models/edge-template-context.model.ts
+++ b/lib/src/graph/models/edge-template-context.model.ts
@@ -1,0 +1,5 @@
+import { TransformedEdge } from './transformed-edge.model';
+
+export interface EdgeTemplateContext<T> {
+  $implicit: TransformedEdge<T>;
+}

--- a/lib/src/graph/models/input-edge.model.ts
+++ b/lib/src/graph/models/input-edge.model.ts
@@ -1,4 +1,4 @@
-export interface InputEdge<T extends object = {}> {
+export interface InputEdge<T = void> {
   id: string;
   sourceId: string;
   targetId: string;

--- a/lib/src/graph/models/input-node.model.ts
+++ b/lib/src/graph/models/input-node.model.ts
@@ -1,4 +1,4 @@
-export interface InputNode<T extends object = {}> {
+export interface InputNode<T = void> {
   id: string;
   data?: T;
 }

--- a/lib/src/graph/models/node-template-context.model.ts
+++ b/lib/src/graph/models/node-template-context.model.ts
@@ -1,0 +1,5 @@
+import { TransformedNode } from './transformed-node.model';
+
+export interface NodeTemplateContext<T> {
+  $implicit: TransformedNode<T>;
+}

--- a/lib/src/graph/models/transformed-edge.model.ts
+++ b/lib/src/graph/models/transformed-edge.model.ts
@@ -1,7 +1,7 @@
-export interface TransformedEdge<T extends object = {}> {
+export interface TransformedEdge<T = {}> {
   id: string;
   sourceId: string;
   targetId: string;
   pathDefinition: string;
-  data?: T;
+  data: T;
 }

--- a/lib/src/graph/models/transformed-node.model.ts
+++ b/lib/src/graph/models/transformed-node.model.ts
@@ -1,4 +1,4 @@
-export interface TransformedNode<T extends object = {}> {
+export interface TransformedNode<T = {}> {
   id: string;
   width: number;
   height: number;
@@ -6,5 +6,5 @@ export interface TransformedNode<T extends object = {}> {
   y: number;
   transform: string;
   isVisible: boolean;
-  data?: T;
+  data: T;
 }

--- a/lib/src/graph/templates.ts
+++ b/lib/src/graph/templates.ts
@@ -1,4 +1,5 @@
 import { Directive, Input, TemplateRef } from '@angular/core';
+import { Subject } from 'rxjs';
 
 import { EdgeTemplateContext } from './models/edge-template-context.model';
 import { InputEdge } from './models/input-edge.model';
@@ -16,8 +17,18 @@ export class DefsTemplateDirective {
   selector: '[nodeTemplate]',
 })
 export class NodeTemplateDirective<T> {
+  /** Subject that emits when input nodes are mutated. */
+  readonly onNodeChanges$: Subject<void> = new Subject();
+
   /** The array of nodes to display in the graph. */
-  @Input('nodeTemplateNodes') inputNodes: InputNode<T>[] = [];
+  private _inputNodes: InputNode<T>[] = [];
+  get inputNodes(): InputNode<T>[] {
+    return this._inputNodes;
+  }
+  @Input('nodeTemplateNodes') set inputNodes(value: InputNode<T>[]) {
+    this._inputNodes = value;
+    this.onNodeChanges$.next();
+  }
 
   static ngTemplateContextGuard<T>(dir: NodeTemplateDirective<T>, ctx: any): ctx is NodeTemplateContext<T> {
     return true;
@@ -30,8 +41,18 @@ export class NodeTemplateDirective<T> {
   selector: '[edgeTemplate]',
 })
 export class EdgeTemplateDirective<T> {
+  /** Subject that emits when input edges are mutated. */
+  readonly onEdgeChanges$: Subject<void> = new Subject();
+
   /** The array of edges to display in the graph. */
-  @Input('edgeTemplateEdges') inputEdges: InputEdge<T>[] = [];
+  private _inputEdges: InputEdge<T>[] = [];
+  get inputEdges(): InputEdge<T>[] {
+    return this._inputEdges;
+  }
+  @Input('edgeTemplateEdges') set inputEdges(value: InputEdge<T>[]) {
+    this._inputEdges = value;
+    this.onEdgeChanges$.next();
+  }
 
   static ngTemplateContextGuard<T>(dir: EdgeTemplateDirective<T>, ctx: unknown): ctx is EdgeTemplateContext<T> {
     return true;

--- a/lib/src/graph/templates.ts
+++ b/lib/src/graph/templates.ts
@@ -16,7 +16,8 @@ export class DefsTemplateDirective {
   selector: '[nodeTemplate]',
 })
 export class NodeTemplateDirective<T> {
-  @Input() nodeTemplateNodes: InputNode<T>[];
+  /** The array of nodes to display in the graph. */
+  @Input('nodeTemplateNodes') inputNodes: InputNode<T>[] = [];
 
   static ngTemplateContextGuard<T>(dir: NodeTemplateDirective<T>, ctx: any): ctx is NodeTemplateContext<T> {
     return true;
@@ -29,7 +30,8 @@ export class NodeTemplateDirective<T> {
   selector: '[edgeTemplate]',
 })
 export class EdgeTemplateDirective<T> {
-  @Input() edgeTemplateEdges: InputEdge<T>[];
+  /** The array of edges to display in the graph. */
+  @Input('edgeTemplateEdges') inputEdges: InputEdge<T>[] = [];
 
   static ngTemplateContextGuard<T>(dir: EdgeTemplateDirective<T>, ctx: unknown): ctx is EdgeTemplateContext<T> {
     return true;

--- a/lib/src/graph/templates.ts
+++ b/lib/src/graph/templates.ts
@@ -1,7 +1,9 @@
-import { Directive, TemplateRef } from '@angular/core';
-import { TransformedEdge } from './models/transformed-edge.model';
+import { Directive, Input, TemplateRef } from '@angular/core';
 
-import { TransformedNode } from './models/transformed-node.model';
+import { EdgeTemplateContext } from './models/edge-template-context.model';
+import { InputEdge } from './models/input-edge.model';
+import { InputNode } from './models/input-node.model';
+import { NodeTemplateContext } from './models/node-template-context.model';
 
 @Directive({
   selector: '[defsTemplate]',
@@ -10,35 +12,26 @@ export class DefsTemplateDirective {
   constructor(public template: TemplateRef<any>) {}
 }
 
-interface NodeTemplateContext<T extends object> {
-  $implicit: TransformedNode<T>;
-}
-
 @Directive({
   selector: '[nodeTemplate]',
 })
 export class NodeTemplateDirective<T> {
-  static ngTemplateContextGuard<T extends object>(
-    dir: NodeTemplateDirective<T>,
-    ctx: unknown,
-  ): ctx is NodeTemplateContext<T> {
+  @Input() nodeTemplateNodes: InputNode<T>[];
+
+  static ngTemplateContextGuard<T>(dir: NodeTemplateDirective<T>, ctx: any): ctx is NodeTemplateContext<T> {
     return true;
   }
 
   constructor(public template: TemplateRef<any>) {}
-}
-interface EdgeTemplateContext<T extends object> {
-  $implicit: TransformedEdge<T>;
 }
 
 @Directive({
   selector: '[edgeTemplate]',
 })
 export class EdgeTemplateDirective<T> {
-  static ngTemplateContextGuard<T extends object>(
-    dir: EdgeTemplateDirective<T>,
-    ctx: unknown,
-  ): ctx is EdgeTemplateContext<T> {
+  @Input() edgeTemplateEdges: InputEdge<T>[];
+
+  static ngTemplateContextGuard<T>(dir: EdgeTemplateDirective<T>, ctx: unknown): ctx is EdgeTemplateContext<T> {
     return true;
   }
 

--- a/lib/src/graph/templates.ts
+++ b/lib/src/graph/templates.ts
@@ -1,0 +1,46 @@
+import { Directive, TemplateRef } from '@angular/core';
+import { TransformedEdge } from './models/transformed-edge.model';
+
+import { TransformedNode } from './models/transformed-node.model';
+
+@Directive({
+  selector: '[defsTemplate]',
+})
+export class DefsTemplateDirective {
+  constructor(public template: TemplateRef<any>) {}
+}
+
+interface NodeTemplateContext<T extends object> {
+  $implicit: TransformedNode<T>;
+}
+
+@Directive({
+  selector: '[nodeTemplate]',
+})
+export class NodeTemplateDirective<T> {
+  static ngTemplateContextGuard<T extends object>(
+    dir: NodeTemplateDirective<T>,
+    ctx: unknown,
+  ): ctx is NodeTemplateContext<T> {
+    return true;
+  }
+
+  constructor(public template: TemplateRef<any>) {}
+}
+interface EdgeTemplateContext<T extends object> {
+  $implicit: TransformedEdge<T>;
+}
+
+@Directive({
+  selector: '[edgeTemplate]',
+})
+export class EdgeTemplateDirective<T> {
+  static ngTemplateContextGuard<T extends object>(
+    dir: EdgeTemplateDirective<T>,
+    ctx: unknown,
+  ): ctx is EdgeTemplateContext<T> {
+    return true;
+  }
+
+  constructor(public template: TemplateRef<any>) {}
+}

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -4,6 +4,7 @@
 
 export { GraphModule } from './graph/graph.module';
 export { GraphComponent } from './graph/graph.component';
+export { DefsTemplateDirective, EdgeTemplateDirective, NodeTemplateDirective } from './graph/templates';
 export { InputEdge } from './graph/models/input-edge.model';
 export { InputNode } from './graph/models/input-node.model';
 export { TransformedEdge } from './graph/models/transformed-edge.model';


### PR DESCRIPTION
* Change the way that nodes and edges are passed as inputs. Instead of passing them through `GraphComponent`, inputs are now passed through newly added structural directives (eg. `*nodeTemplate="let node; nodes: nodes"`). The advantage of doing it this way is that we get full type completion in the template, even for the `data` generic.
* Minor changes to `TransformedNode`, `TransformedEdge`, `InputNode`, and `InputEdge` interfaces.